### PR TITLE
Custom trim patterns in getReflectionDocComment()

### DIFF
--- a/src/ReflectionDocComment.php
+++ b/src/ReflectionDocComment.php
@@ -47,9 +47,9 @@ class ReflectionDocComment
         if (isset($comment[0]) === true) {
             $description = $comment[0];
             $description = preg_split("/\n|\n\r/", $description);
-            array_walk($description, function (& $value) {
+            array_walk($description, function (& $value, $key, $trimLinePattern) {
                 $value = trim($value, $trimLinePattern);
-            });
+            }, $trimLinePattern);
 
             foreach ($description as $key => $descLine) {
                 if ($descLine !== '') {

--- a/src/ReflectionDocComment.php
+++ b/src/ReflectionDocComment.php
@@ -35,8 +35,9 @@ class ReflectionDocComment
      * Constructor.
      *
      * @param string $comment The original document block comment.
+     * @param string $trimLinePattern Pattern for trim() function applied to each line. Usefull to leave spaces or tabs. The default is the same as calling trim() without the argument.
      */
-    public function __construct($comment)
+    public function __construct($comment, $trimLinePattern = " \t\n\r\0\x0B")
     {
         $this->originalDocBlock = trim((string)$comment);
 
@@ -47,7 +48,7 @@ class ReflectionDocComment
             $description = $comment[0];
             $description = preg_split("/\n|\n\r/", $description);
             array_walk($description, function (& $value) {
-                $value = trim($value);
+                $value = trim($value, $trimLinePattern);
             });
 
             foreach ($description as $key => $descLine) {

--- a/src/ReflectionDocCommentTrait.php
+++ b/src/ReflectionDocCommentTrait.php
@@ -17,13 +17,14 @@ trait ReflectionDocCommentTrait
 
     /**
      * Get the document of the method.
-     *
+     * 
+     * @param string $trimLinePattern Pattern for trim() function applied to each line. Usefull to leave spaces or tabs. The default is the same as calling trim() without the argument.
      * @return \Wingu\OctopusCore\Reflection\ReflectionDocComment
      */
-    public function getReflectionDocComment()
+    public function getReflectionDocComment($trimLinePattern = " \t\n\r\0\x0B")
     {
         if ($this->reflectionDocComment === null) {
-            $this->reflectionDocComment = new ReflectionDocComment((string)$this->getDocComment());
+            $this->reflectionDocComment = new ReflectionDocComment((string)$this->getDocComment(), $trimLinePattern);
         }
 
         return $this->reflectionDocComment;


### PR DESCRIPTION
Hi!

First of all, many thanks for this handy library!

I've added the option to passe a custom pattern for the trim() function being applied to each comment line because just using trim() without a pattern resultet in loss of tabs and whitespaces, that are very handy for code examples in doc blocks and also often used for complex custom annotations (like doctrine). 

This change is completely backwards compatible. If no parameter is passed to getReflectionDocComment() everything remains just like it was.

Kind regards,

Andrej Kabachnik