### PR TITLE
FIX ReflectionConstant::getDeclaringClass() returned wrong class

### DIFF
--- a/tests/Unit/Fixtures/ImplementorClass1.php
+++ b/tests/Unit/Fixtures/ImplementorClass1.php
@@ -7,6 +7,13 @@ class ImplementorClass1 implements Interface1, Interface3 {
     public $property3 = 'default value';
 
     const CONSTANT1 = 'VALUE1';
+    
+    /**
+     * This is *another comment*
+     */
+    const CONSTANT3 = 'VALUE1_WITH_COMMENTS';
+    
+    const CONSTANT4 = 'VALUE4';
 
     public function method1() {
     }

--- a/tests/Unit/Fixtures/ImplementorClass1.php
+++ b/tests/Unit/Fixtures/ImplementorClass1.php
@@ -12,8 +12,6 @@ class ImplementorClass1 implements Interface1, Interface3 {
      * This is *another comment*
      */
     const CONSTANT3 = 'VALUE1_WITH_COMMENTS';
-    
-    const CONSTANT4 = 'VALUE4';
 
     public function method1() {
     }

--- a/tests/Unit/ReflectionClass/ReflectionClassPropertiesTest.php
+++ b/tests/Unit/ReflectionClass/ReflectionClassPropertiesTest.php
@@ -123,20 +123,24 @@ class ReflectionClassPropertiesTest extends TestCase
     {
         $reflection = new ReflectionClass('\Wingu\OctopusCore\Reflection\Tests\Unit\Fixtures\ImplementorClass2');
         $actual = $reflection->getConstants();
-        $expected = new ReflectionConstant('\Wingu\OctopusCore\Reflection\Tests\Unit\Fixtures\ImplementorClass2',
+        $expected1 = new ReflectionConstant('\Wingu\OctopusCore\Reflection\Tests\Unit\Fixtures\ImplementorClass2',
             'CONSTANT1');
-        $this->assertEquals(array('CONSTANT1' => $expected), $actual);
+        $expected2 = new ReflectionConstant('\Wingu\OctopusCore\Reflection\Tests\Unit\Fixtures\ImplementorClass2',
+            'CONSTANT3');
+        $this->assertEquals(array('CONSTANT1' => $expected1, 'CONSTANT3' => $expected2), $actual);
     }
 
     public function testGetConstantsWithConstantReturnReflectionConstantArray()
     {
         $reflection = new ReflectionClass('\Wingu\OctopusCore\Reflection\Tests\Unit\Fixtures\ImplementorClass3');
         $actual = $reflection->getConstants();
+        $expectedConstant3 = new ReflectionConstant('\Wingu\OctopusCore\Reflection\Tests\Unit\Fixtures\ImplementorClass3',
+            'CONSTANT3');
         $expectedConstant2 = new ReflectionConstant('\Wingu\OctopusCore\Reflection\Tests\Unit\Fixtures\ImplementorClass3',
             'CONSTANT2');
         $expectedConstant1 = new ReflectionConstant('\Wingu\OctopusCore\Reflection\Tests\Unit\Fixtures\ImplementorClass3',
             'CONSTANT1');
-        $expected = array('CONSTANT2' => $expectedConstant2, 'CONSTANT1' => $expectedConstant1);
+        $expected = array('CONSTANT2' => $expectedConstant2, 'CONSTANT1' => $expectedConstant1, 'CONSTANT3' => $expectedConstant3);
         $this->assertEquals($expected, $actual);
     }
 

--- a/tests/Unit/ReflectionConstantTest.php
+++ b/tests/Unit/ReflectionConstantTest.php
@@ -60,6 +60,19 @@ class ReflectionConstantTest extends TestCase
      */';
         $this->assertEquals($expected, $actual);
     }
+    
+    public function testGetDocCommentWithValidCommentInheritedReturnTheDocComment()
+    {
+        $reflectionConstant = new ReflectionConstant(
+            'Wingu\OctopusCore\Reflection\Tests\Unit\Fixtures\ImplementorClass3',
+            'CONSTANT3'
+            );
+        $actual = $reflectionConstant->getDocComment();
+        $expected = '/**
+     * This is *another comment*
+     */';
+        $this->assertEquals($expected, $actual);
+    }
 
     public function testGetDocCommentFromBuiltInClassReturnFalse()
     {


### PR DESCRIPTION
ISSUE: ReflectionClass::getConstants() returned constants defined in that class and its parent classes. However, ReflectionConstant::getDocComment() only searched in the class being reflected - not in its parent classes.

CAUSE: ReflectionConstant::getDeclaringClass() simply returned the class being reflected.

SOLUTION: now using ReflectionClass::getOwnConstants() to check which one of the classes actually declared the constant. This is done in ReflectionConstant::getDeclaringClass() and not in the constructor to avoid recursion.

Also added a small fix to ReflectionConstant::getCurrentConstantKeyFromClassTokens() to return 0 if no matching constant name found. Otherwise the result was the comment for the last constant with non-empty comment in the iteration.