### PR TITLE
PHP 8.0 compat

### DIFF
--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -229,12 +229,11 @@ class ReflectionClass extends \ReflectionClass
     /**
      * Get the constants that are defined in the class
      *
-     * @param integer|null $filter Filter for the constants.
      * @return \Wingu\OctopusCore\Reflection\ReflectionConstant[] the array of constants
      */
     public function getConstants($filter = null)
     {
-        $constants = parent::getConstants($filter);
+        $constants = parent::getConstants();
         $returnConstants = array();
         foreach ($constants as $key => $value) {
             $returnConstants[$key] = new ReflectionConstant($this->getName(), $key);

--- a/src/ReflectionClass.php
+++ b/src/ReflectionClass.php
@@ -229,11 +229,12 @@ class ReflectionClass extends \ReflectionClass
     /**
      * Get the constants that are defined in the class
      *
+     * @param integer|null $filter Filter for the constants.
      * @return \Wingu\OctopusCore\Reflection\ReflectionConstant[] the array of constants
      */
-    public function getConstants()
+    public function getConstants($filter = null)
     {
-        $constants = parent::getConstants();
+        $constants = parent::getConstants($filter);
         $returnConstants = array();
         foreach ($constants as $key => $value) {
             $returnConstants[$key] = new ReflectionConstant($this->getName(), $key);


### PR DESCRIPTION
Without it, you'll get `PHP Fatal error: Declaration of Wingu\OctopusCore\Reflection\ReflectionClass::getConstants() must be compatible with ReflectionClass::getConstants(?int $filter = null)`

Proposed declaration is back compatible with PHP <8.0

https://github.com/dragosprotung/php2wsdl/issues/28