### PR TITLE
Upgrade phpunit to 9 and fix tests. Improve php 8 support 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         php-versions:
@@ -26,7 +26,7 @@ jobs:
       - name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          coverage: pcov
+          coverage: xdebug
           php-version: ${{ matrix.php-versions }}
 
       - name: Install dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: composer update --prefer-dist --no-progress --no-suggest
 
       - name: Run tests
-        run: vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
+        run: vendor/bin/simple-phpunit --coverage-text --coverage-clover=coverage.clover
 
 #      - name: Upload code coverage
 #        run: vendor/bin/ocular code-coverage:upload --format=php-clover coverage.clover

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor/
 build/
 composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php": ">=5.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.0",
+    "symfony/phpunit-bridge": "^5.0",
     "scrutinizer/ocular": "~1.1"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "php": ">=5.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "4.*",
+    "phpunit/phpunit": "^9.0",
     "scrutinizer/ocular": "~1.1"
   },
   "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,32 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-  bootstrap="vendor/autoload.php"
-  backupGlobals="false"
-  backupStaticAttributes="false"
-  colors="true"
-  verbose="true"
-  convertErrorsToExceptions="true"
-  convertNoticesToExceptions="true"
-  convertWarningsToExceptions="true"
-  processIsolation="false"
-  stopOnFailure="false"
->
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-    <report>
-      <clover outputFile="build/logs/clover.xml"/>
-      <html outputDirectory="build/coverage"/>
-      <text outputFile="build/coverage.txt"/>
-    </report>
-  </coverage>
-  <testsuites>
-    <testsuite name="Wingu OctopusCore Test Suite">
-      <directory>tests</directory>
-    </testsuite>
-  </testsuites>
-  <logging>
-    <junit outputFile="build/report.junit.xml"/>
-  </logging>
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Wingu OctopusCore Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src/</directory>
+        </whitelist>
+    </filter>
+    <logging>
+        <log type="tap" target="build/report.tap"/>
+        <log type="junit" target="build/report.junit.xml"/>
+        <log type="coverage-html" target="build/coverage"/>
+        <log type="coverage-text" target="build/coverage.txt"/>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+    </logging>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,4 +26,7 @@
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
+    </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -26,7 +26,4 @@
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>
-    <php>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
-    </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,29 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Wingu OctopusCore Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+  bootstrap="vendor/autoload.php"
+  backupGlobals="false"
+  backupStaticAttributes="false"
+  colors="true"
+  verbose="true"
+  convertErrorsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertWarningsToExceptions="true"
+  processIsolation="false"
+  stopOnFailure="false"
+>
+  <coverage>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+    <report>
+      <clover outputFile="build/logs/clover.xml"/>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Wingu OctopusCore Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
 </phpunit>

--- a/src/ReflectionClassUse.php
+++ b/src/ReflectionClassUse.php
@@ -135,8 +135,14 @@ class ReflectionClassUse implements \Reflector
 
                 continue;
             }
-
-            if (($token[0] === T_STRING || $token[0] === T_NS_SEPARATOR) === true) {
+            $tokenTypes = array(T_STRING, T_NS_SEPARATOR);
+            if (defined('T_NAME_QUALIFIED')) {
+                $tokenTypes[] = T_NAME_QUALIFIED;
+            }
+            if (defined('T_NAME_FULLY_QUALIFIED')) {
+                $tokenTypes[] = T_NAME_FULLY_QUALIFIED;
+            }
+            if (in_array($token[0], $tokenTypes, true)) {
                 $class .= $token[1];
             } else {
                 if ($token === ',') {

--- a/src/ReflectionFile.php
+++ b/src/ReflectionFile.php
@@ -71,7 +71,8 @@ class ReflectionFile
         $classLevel = 0;
         $level = 0;
         $res = $uses = array();
-        while (list(, $token) = each($tokens)) {
+        while ($token = current($tokens)) {
+            next($tokens);
             switch (is_array($token) ? $token[0] : $token) {
                 case T_CLASS:
                 case T_INTERFACE:
@@ -87,7 +88,11 @@ class ReflectionFile
                     }
                     break;
                 case T_NAMESPACE:
-                    $namespace = '\\' . ltrim($this->fetch($tokens, array(T_STRING, T_NS_SEPARATOR)), '\\');
+                    $tokenTypes = array(T_STRING, T_NS_SEPARATOR);
+                    if (defined('T_NAME_QUALIFIED')) {
+                        $tokenTypes[] = T_NAME_QUALIFIED;
+                    }
+                    $namespace = '\\' . ltrim($this->fetch($tokens, $tokenTypes), '\\');
                     $res[$namespace] = array();
                     $uses = array();
                     break;

--- a/src/ReflectionFile.php
+++ b/src/ReflectionFile.php
@@ -92,6 +92,9 @@ class ReflectionFile
                     if (defined('T_NAME_QUALIFIED')) {
                         $tokenTypes[] = T_NAME_QUALIFIED;
                     }
+                    if (defined('T_NAME_FULLY_QUALIFIED')) {
+                        $tokenTypes[] = T_NAME_FULLY_QUALIFIED;
+                    }
                     $namespace = '\\' . ltrim($this->fetch($tokens, $tokenTypes), '\\');
                     $res[$namespace] = array();
                     $uses = array();

--- a/src/ReflectionParameter.php
+++ b/src/ReflectionParameter.php
@@ -34,7 +34,15 @@ class ReflectionParameter extends \ReflectionParameter
      */
     public function getClass()
     {
-        $class = parent::getClass();
+        $class = null;
+        if (PHP_VERSION_ID < 80000) {
+            $class = parent::getClass();
+        } else {
+            $type = parent::getType();
+            if ($type instanceof \ReflectionNamedType && class_exists($type->getName())) {
+                $class = $type;
+            }
+        }
         if ($class !== null) {
             $class = new ReflectionClass($class->getName());
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,10 +2,12 @@
 
 namespace Wingu\OctopusCore\Reflection\Tests;
 
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
 /**
  * Base class for test cases.
  */
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends BaseTestCase
 {
 
     /**

--- a/tests/Unit/Annotation/AnnotationsCollectionTest.php
+++ b/tests/Unit/Annotation/AnnotationsCollectionTest.php
@@ -129,7 +129,7 @@ class AnnotationsCollectionTest extends TestCase
 
     public function testSetTagMapper()
     {
-        $tm = $this->getMock('Wingu\OctopusCore\Reflection\Annotation\TagMapper');
+        $tm = $this->getMockBuilder('\Wingu\OctopusCore\Reflection\Annotation\TagMapper')->getMock();
         $ac = new AnnotationsCollection('');
         $ac->setTagMapper($tm);
 
@@ -139,7 +139,10 @@ class AnnotationsCollectionTest extends TestCase
     public function testGetAnnotationClassWithTagMapper()
     {
         $ac = new AnnotationsCollection('');
-        $tm = $this->getMock('Wingu\OctopusCore\Reflection\Annotation\TagMapper', ['hasMappedTag', 'getMappedTag']);
+        $tm = $this->getMockBuilder('\Wingu\OctopusCore\Reflection\Annotation\TagMapper')
+            ->setMethods(['hasMappedTag', 'getMappedTag'])
+            ->getMock()
+        ;
         $tm->expects($this->any())
             ->method('hasMappedTag')
             ->will($this->returnValue(true));
@@ -187,7 +190,10 @@ class AnnotationsCollectionTest extends TestCase
     public function testGetAnnotationClassPriorityOfTagMapper($tag)
     {
         $ac = new AnnotationsCollection('');
-        $tm = $this->getMock('Wingu\OctopusCore\Reflection\Annotation\TagMapper', ['hasMappedTag', 'getMappedTag']);
+        $tm = $this->getMockBuilder('\Wingu\OctopusCore\Reflection\Annotation\TagMapper')
+            ->setMethods(['hasMappedTag', 'getMappedTag'])
+            ->getMock()
+        ;
         $tm->expects($this->any())
             ->method('hasMappedTag')
             ->will($this->returnValue(true));
@@ -239,11 +245,9 @@ class AnnotationsCollectionTest extends TestCase
         $this->assertSame($tag, $annotation[0]->getTagName());
     }
 
-    /**
-     * @expectedException \Wingu\OctopusCore\Reflection\Annotation\Exceptions\OutOfBoundsException
-     */
     public function testGetAnnotationNotFound()
     {
+        $this->expectException('\Wingu\OctopusCore\Reflection\Annotation\Exceptions\OutOfBoundsException');
         $ac = new AnnotationsCollection('');
         $ac->getAnnotation('tag');
     }

--- a/tests/Unit/Annotation/ParserTest.php
+++ b/tests/Unit/Annotation/ParserTest.php
@@ -137,11 +137,9 @@ class ParserTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \Wingu\OctopusCore\Reflection\Annotation\Exceptions\RuntimeException
-     */
     public function testParseCommentWithAnnotationWithMultiLineValueNotCloseNestedArrayThrowsRuntimeException()
     {
+        $this->expectException('\Wingu\OctopusCore\Reflection\Annotation\Exceptions\RuntimeException');
         $parser = new Parser('/** Test
                 * @annotationB(a b
                 * c d e f

--- a/tests/Unit/Annotation/TagMapperTest.php
+++ b/tests/Unit/Annotation/TagMapperTest.php
@@ -71,9 +71,6 @@ class TagMapperTest extends TestCase
         $this->assertSame($tagMapper->getMappedTag($tag), get_class($class));
     }
 
-    /**
-     * @expectedException \Wingu\OctopusCore\Reflection\Annotation\Exceptions\OutOfBoundsException
-     */
     public function testGetMappedTagException()
     {
         $this->expectException('\Wingu\OctopusCore\Reflection\Annotation\Exceptions\OutOfBoundsException');

--- a/tests/Unit/Annotation/TagMapperTest.php
+++ b/tests/Unit/Annotation/TagMapperTest.php
@@ -24,27 +24,25 @@ class TagMapperTest extends TestCase
     public function testMapTag($tag)
     {
         $tagMapper = new TagMapper();
-        $class = $this->getMock('\Wingu\OctopusCore\Reflection\Annotation\Tags\TagInterface');
+        $class = $this->getMockBuilder('\Wingu\OctopusCore\Reflection\Annotation\Tags\TagInterface')->getMock();
         $tagMapper->mapTag($tag, get_class($class));
         $this->assertTrue($tagMapper->hasMappedTag($tag));
     }
 
     /**
      * @dataProvider getDataMapTagExceptionsInvalidTag
-     * @expectedException \Wingu\OctopusCore\Reflection\Annotation\Exceptions\InvalidArgumentException
      */
     public function testMapTagExceptionsInvalidTag($tag)
     {
+        $this->expectException('\Wingu\OctopusCore\Reflection\Annotation\Exceptions\InvalidArgumentException');
         $tagMapper = new TagMapper();
-        $class = $this->getMock('\Wingu\OctopusCore\Reflection\Annotation\Tags\TagInterface');
+        $class = $this->getMockBuilder('\Wingu\OctopusCore\Reflection\Annotation\Tags\TagInterface')->getMock();
         $tagMapper->mapTag($tag, get_class($class));
     }
 
-    /**
-     * @expectedException \Wingu\OctopusCore\Reflection\Annotation\Exceptions\InvalidArgumentException
-     */
     public function testMapTagExceptionsInvalidClass()
     {
+        $this->expectException('\Wingu\OctopusCore\Reflection\Annotation\Exceptions\InvalidArgumentException');
         $tagMapper = new TagMapper();
         $tagMapper->mapTag('tag', 'stdClass');
     }
@@ -55,7 +53,7 @@ class TagMapperTest extends TestCase
     public function testGetMappedTags($tag)
     {
         $tagMapper = new TagMapper();
-        $class = $this->getMock('\Wingu\OctopusCore\Reflection\Annotation\Tags\TagInterface');
+        $class = $this->getMockBuilder('\Wingu\OctopusCore\Reflection\Annotation\Tags\TagInterface')->getMock();
         $tagMapper->mapTag($tag, get_class($class));
 
         $this->assertArrayHasKey($tag, $tagMapper->getMappedTags());
@@ -67,7 +65,7 @@ class TagMapperTest extends TestCase
     public function testGetMappedTag($tag)
     {
         $tagMapper = new TagMapper();
-        $class = $this->getMock('\Wingu\OctopusCore\Reflection\Annotation\Tags\TagInterface');
+        $class = $this->getMockBuilder('\Wingu\OctopusCore\Reflection\Annotation\Tags\TagInterface')->getMock();
         $tagMapper->mapTag($tag, get_class($class));
 
         $this->assertSame($tagMapper->getMappedTag($tag), get_class($class));
@@ -78,8 +76,9 @@ class TagMapperTest extends TestCase
      */
     public function testGetMappedTagException()
     {
+        $this->expectException('\Wingu\OctopusCore\Reflection\Annotation\Exceptions\OutOfBoundsException');
         $tagMapper = new TagMapper();
-        $class = $this->getMock('\Wingu\OctopusCore\Reflection\Annotation\Tags\TagInterface');
+        $class = $this->getMockBuilder('\Wingu\OctopusCore\Reflection\Annotation\Tags\TagInterface')->getMock();
         $tagMapper->mapTag('tag', get_class($class));
 
         $tagMapper->getMappedTag('tag2');
@@ -87,12 +86,14 @@ class TagMapperTest extends TestCase
 
     public function testMergeTagMapperNoOverwrite()
     {
-        $tagClass1 = $this->getMock('\Wingu\OctopusCore\Reflection\Annotation\Tags\TagInterface', array(), array(),
-            'Mock_tagMapperWithOverwrite1');
+        $tagClass1 = $this->getMockBuilder('\Wingu\OctopusCore\Reflection\Annotation\Tags\TagInterface')
+            ->setMockClassName('Mock_tagMapperWithOverwrite1')->getMock()
+        ;
         $tagClass1 = get_class($tagClass1);
 
-        $tagClass2 = $this->getMock('\Wingu\OctopusCore\Reflection\Annotation\Tags\TagInterface', array(), array(),
-            'Mock_tagMapperWithOverwrite2');
+        $tagClass2 = $this->getMockBuilder('\Wingu\OctopusCore\Reflection\Annotation\Tags\TagInterface')
+            ->setMockClassName('Mock_tagMapperWithOverwrite2')->getMock()
+        ;
         $tagClass2 = get_class($tagClass2);
 
         $tagMapper1 = new TagMapper();
@@ -112,12 +113,14 @@ class TagMapperTest extends TestCase
 
     public function testMergeTagMapperWithOverwrite()
     {
-        $tagClass1 = $this->getMock('\Wingu\OctopusCore\Reflection\Annotation\Tags\TagInterface', array(), array(),
-            'Mock_tagMapperWithOverwrite1');
+        $tagClass1 = $this->getMockBuilder('\Wingu\OctopusCore\Reflection\Annotation\Tags\TagInterface')
+            ->setMockClassName('Mock_tagMapperWithOverwrite1')->getMock()
+        ;
         $tagClass1 = get_class($tagClass1);
 
-        $tagClass2 = $this->getMock('\Wingu\OctopusCore\Reflection\Annotation\Tags\TagInterface', array(), array(),
-            'Mock_tagMapperWithOverwrite2');
+        $tagClass2 = $this->getMockBuilder('\Wingu\OctopusCore\Reflection\Annotation\Tags\TagInterface')
+            ->setMockClassName('Mock_tagMapperWithOverwrite2')->getMock()
+        ;
         $tagClass2 = get_class($tagClass2);
 
         $tagMapper1 = new TagMapper();

--- a/tests/Unit/Annotation/Tags/BaseTagTest.php
+++ b/tests/Unit/Annotation/Tags/BaseTagTest.php
@@ -23,8 +23,11 @@ class BaseTagTest extends TestCase
      */
     public function testBaseTag($tag, $description, $expectedTag, $expectedDescription)
     {
-        $ad = $this->getMock('Wingu\OctopusCore\Reflection\Annotation\AnnotationDefinition',
-            ['getTag', 'getDescription'], ['']);
+        $ad = $this->getMockBuilder('Wingu\OctopusCore\Reflection\Annotation\AnnotationDefinition')
+            ->setMethods(['getTag', 'getDescription'])
+            ->setConstructorArgs([''])
+            ->getMock()
+        ;
         $ad->expects($this->any())
             ->method('getTag')
             ->will($this->returnValue($tag));

--- a/tests/Unit/Annotation/Tags/ParamTagTest.php
+++ b/tests/Unit/Annotation/Tags/ParamTagTest.php
@@ -27,8 +27,11 @@ class ParamTagTest extends TestCase
      */
     public function testParamTag($description, $expectedParamType, $expectedParamName, $expectedParamDescription)
     {
-        $ad = $this->getMock('Wingu\OctopusCore\Reflection\Annotation\AnnotationDefinition',
-            ['getTag', 'getDescription'], ['']);
+        $ad = $this->getMockBuilder('Wingu\OctopusCore\Reflection\Annotation\AnnotationDefinition')
+            ->setMethods(['getTag', 'getDescription'])
+            ->setConstructorArgs([''])
+            ->getMock()
+        ;
         $ad->expects($this->any())
             ->method('getTag')
             ->will($this->returnValue('param'));
@@ -43,12 +46,14 @@ class ParamTagTest extends TestCase
         $this->assertSame($expectedParamDescription, $paramTag->getParamDescription());
     }
 
-    /**
-     * @expectedException \Wingu\OctopusCore\Reflection\Annotation\Exceptions\InvalidArgumentException
-     */
     public function testVarTagWrongAnnotationDefinition()
     {
-        $ad = $this->getMock('Wingu\OctopusCore\Reflection\Annotation\AnnotationDefinition', ['getTag'], ['']);
+        $this->expectException('\Wingu\OctopusCore\Reflection\Annotation\Exceptions\InvalidArgumentException');
+        $ad = $this->getMockBuilder('Wingu\OctopusCore\Reflection\Annotation\AnnotationDefinition')
+            ->setMethods(['getTag'])
+            ->setConstructorArgs([''])
+            ->getMock()
+        ;
         $ad->expects($this->any())
             ->method('getTag')
             ->will($this->returnValue('wrongtag'));

--- a/tests/Unit/Annotation/Tags/ReturnTagTest.php
+++ b/tests/Unit/Annotation/Tags/ReturnTagTest.php
@@ -30,8 +30,11 @@ class ReturnTagTest extends TestCase
      */
     public function testReturnTag($description, $expectedReturnType, $expectedReturnDescription)
     {
-        $ad = $this->getMock('Wingu\OctopusCore\Reflection\Annotation\AnnotationDefinition',
-            ['getTag', 'getDescription'], ['']);
+        $ad = $this->getMockBuilder('Wingu\OctopusCore\Reflection\Annotation\AnnotationDefinition')
+            ->setMethods(['getTag', 'getDescription'])
+            ->setConstructorArgs([''])
+            ->getMock()
+        ;
         $ad->expects($this->any())
             ->method('getTag')
             ->will($this->returnValue('return'));
@@ -46,12 +49,14 @@ class ReturnTagTest extends TestCase
         $this->assertSame($expectedReturnDescription, $returnTag->getReturnDescription());
     }
 
-    /**
-     * @expectedException \Wingu\OctopusCore\Reflection\Annotation\Exceptions\InvalidArgumentException
-     */
     public function testReturnTagWrongAnnotationDefinition()
     {
-        $ad = $this->getMock('Wingu\OctopusCore\Reflection\Annotation\AnnotationDefinition', ['getTag'], ['']);
+        $this->expectException('\Wingu\OctopusCore\Reflection\Annotation\Exceptions\InvalidArgumentException');
+        $ad = $this->getMockBuilder('Wingu\OctopusCore\Reflection\Annotation\AnnotationDefinition')
+            ->setMethods(['getTag'])
+            ->setConstructorArgs([''])
+            ->getMock()
+        ;
         $ad->expects($this->any())
             ->method('getTag')
             ->will($this->returnValue('wrongtag'));

--- a/tests/Unit/Annotation/Tags/VarTagTest.php
+++ b/tests/Unit/Annotation/Tags/VarTagTest.php
@@ -28,8 +28,11 @@ class VarTagTest extends TestCase
      */
     public function testVarTag($description, $expectedVarType)
     {
-        $ad = $this->getMock('Wingu\OctopusCore\Reflection\Annotation\AnnotationDefinition',
-            ['getTag', 'getDescription'], ['']);
+        $ad = $this->getMockBuilder('Wingu\OctopusCore\Reflection\Annotation\AnnotationDefinition')
+            ->setMethods(['getTag', 'getDescription'])
+            ->setConstructorArgs([''])
+            ->getMock()
+        ;
         $ad->expects($this->any())
             ->method('getTag')
             ->will($this->returnValue('var'));
@@ -43,12 +46,14 @@ class VarTagTest extends TestCase
         $this->assertSame($expectedVarType, $returnTag->getVarType());
     }
 
-    /**
-     * @expectedException \Wingu\OctopusCore\Reflection\Annotation\Exceptions\InvalidArgumentException
-     */
     public function testVarTagWrongAnnotationDefinition()
     {
-        $ad = $this->getMock('Wingu\OctopusCore\Reflection\Annotation\AnnotationDefinition', ['getTag'], ['']);
+        $this->expectException('\Wingu\OctopusCore\Reflection\Annotation\Exceptions\InvalidArgumentException');
+        $ad = $this->getMockBuilder('Wingu\OctopusCore\Reflection\Annotation\AnnotationDefinition')
+            ->setMethods(['getTag'])
+            ->setConstructorArgs([''])
+            ->getMock()
+        ;
         $ad->expects($this->any())
             ->method('getTag')
             ->will($this->returnValue('wrongtag'));

--- a/tests/Unit/Fixtures/GetMethodClass.php
+++ b/tests/Unit/Fixtures/GetMethodClass.php
@@ -28,6 +28,6 @@ class GetMethodClass {
     final public static function getMethodPublicFinalStatic() {
     }
 
-    final private static function getMethodPrivateFinalStatic() {
+    private static function getMethodPrivateFinalStatic() {
     }
 }

--- a/tests/Unit/ReflectionClass/ReflectionClassGetBodyTest.php
+++ b/tests/Unit/ReflectionClass/ReflectionClassGetBodyTest.php
@@ -29,11 +29,9 @@ class ReflectionClassGetBodyTest extends TestCase
         $this->assertSame($expected, $reflection->getBody());
     }
 
-    /**
-     * @expectedException \Wingu\OctopusCore\Reflection\Exceptions\RuntimeException
-     */
     public function testGetBodyInternalClass()
     {
+        $this->expectException('\Wingu\OctopusCore\Reflection\Exceptions\RuntimeException');
         $reflection = new ReflectionClass('ReflectionClass');
         $reflection->getBody();
     }

--- a/tests/Unit/ReflectionClass/ReflectionClassMethodsTest.php
+++ b/tests/Unit/ReflectionClass/ReflectionClassMethodsTest.php
@@ -70,7 +70,7 @@ class ReflectionClassMethodsTest extends TestCase
         $this->assertCount(3, $methodsStatic, 'Failed getting the static methods.');
 
         $methodsFinal = $reflection->getMethods(ReflectionMethod::IS_FINAL);
-        $this->assertCount(3, $methodsFinal, 'Failed getting the final methods.');
+        $this->assertCount(2, $methodsFinal, 'Failed getting the final methods.');
 
         $reflectionAbstract = new ReflectionClass('\Wingu\OctopusCore\Reflection\Tests\Unit\Fixtures\AbstractClass');
         $methodsAbstract = $reflectionAbstract->getMethods(ReflectionMethod::IS_ABSTRACT);

--- a/tests/Unit/ReflectionClassUseTest.php
+++ b/tests/Unit/ReflectionClassUseTest.php
@@ -35,6 +35,8 @@ class ReflectionClassUseTest extends TestCase
      */
     public function testGetConflictResolutions($traitName, $expected)
     {
+        $this->markTestSkipped('Do not know how to resolve it');
+
         $reflection = new ReflectionClassUse('Wingu\OctopusCore\Reflection\Tests\Unit\Fixtures\ReflectionClassUse',
             $traitName);
         $actual = $reflection->getConflictResolutions();
@@ -43,24 +45,26 @@ class ReflectionClassUseTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
-    /**
-     * @expectedException \Wingu\OctopusCore\Reflection\Exceptions\InvalidArgumentException
-     * @expectedExceptionMessage Could not find the trait "dummyTrait".
-     */
     public function testInvalidTraitName()
     {
+        $this->expectException('\Wingu\OctopusCore\Reflection\Exceptions\InvalidArgumentException');
+        $this->expectExceptionMessage('Could not find the trait "dummyTrait".');
         new ReflectionClassUse('Wingu\OctopusCore\Reflection\Tests\Unit\Fixtures\ReflectionClassUse', 'dummyTrait');
     }
 
-    /**
-     * @expectedException \Wingu\OctopusCore\Reflection\Exceptions\InvalidArgumentException
-     */
     public function testBadUseStatements()
     {
-        $mockReflectionClass = $this->getMock('Wingu\OctopusCore\Reflection\ReflectionClass', ['getBody'], [], '',
-            false);
+        $this->expectException('\Wingu\OctopusCore\Reflection\Exceptions\InvalidArgumentException');
+        $mockReflectionClass = $this->getMockBuilder('Wingu\OctopusCore\Reflection\ReflectionClass')
+            ->setMethods(['getBody'])
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
         $mockReflectionClass->expects($this->any())->method('getBody')->will($this->returnValue('use "a";'));
-        $mock = $this->getMock('Wingu\OctopusCore\Reflection\ReflectionClassUse', null, [], '', false);
+        $mock = $this->getMockBuilder('Wingu\OctopusCore\Reflection\ReflectionClassUse')
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
         $this->setProperty($mock, 'declaringClass', $mockReflectionClass);
         $this->callMethod($mock, 'findConflictResolutions');
     }

--- a/tests/Unit/ReflectionClassUseTest.php
+++ b/tests/Unit/ReflectionClassUseTest.php
@@ -35,8 +35,6 @@ class ReflectionClassUseTest extends TestCase
      */
     public function testGetConflictResolutions($traitName, $expected)
     {
-        $this->markTestSkipped('Do not know how to resolve it');
-
         $reflection = new ReflectionClassUse('Wingu\OctopusCore\Reflection\Tests\Unit\Fixtures\ReflectionClassUse',
             $traitName);
         $actual = $reflection->getConflictResolutions();

--- a/tests/Unit/ReflectionFunctionTest.php
+++ b/tests/Unit/ReflectionFunctionTest.php
@@ -64,12 +64,10 @@ class ReflectionFunctionTest extends TestCase
         $this->assertSame($expected, $reflectionFunction->getBody());
     }
 
-    /**
-     * @expectedException \Wingu\OctopusCore\Reflection\Exceptions\RuntimeException
-     * @expectedExceptionMessage Can not get body of a function that is internal.
-     */
     public function testGetBodyInternalFunction()
     {
+        $this->expectException('\Wingu\OctopusCore\Reflection\Exceptions\RuntimeException');
+        $this->expectExceptionMessage('Can not get body of a function that is internal.');
         $reflectionFunction = new ReflectionFunction('php_sapi_name');
         $reflectionFunction->getBody();
     }

--- a/tests/Unit/ReflectionMethodTest.php
+++ b/tests/Unit/ReflectionMethodTest.php
@@ -125,30 +125,24 @@ class ReflectionMethodTest extends TestCase
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @expectedException \Wingu\OctopusCore\Reflection\Exceptions\RuntimeException
-     */
     public function testGetBodyMethodFromInternalClass()
     {
+        $this->expectException('\Wingu\OctopusCore\Reflection\Exceptions\RuntimeException');
         $reflectionMethod = new ReflectionMethod('ArrayIterator', 'count');
         $reflectionMethod->getBody();
     }
 
-    /**
-     * @expectedException \Wingu\OctopusCore\Reflection\Exceptions\RuntimeException
-     */
     public function testGetBodyMethodFromAbstractClass()
     {
+        $this->expectException('\Wingu\OctopusCore\Reflection\Exceptions\RuntimeException');
         $reflectionMethod = new ReflectionMethod('Wingu\OctopusCore\Reflection\Tests\Unit\Fixtures\AbstractClass',
             'getMethodAbstract');
         $reflectionMethod->getBody();
     }
 
-    /**
-     * @expectedException \Wingu\OctopusCore\Reflection\Exceptions\RuntimeException
-     */
     public function testGetBodyMethodFromInterface()
     {
+        $this->expectException('\Wingu\OctopusCore\Reflection\Exceptions\RuntimeException');
         $reflectionMethod = new ReflectionMethod('Wingu\OctopusCore\Reflection\Tests\Unit\Fixtures\SimpleInterface',
             'simpleFunction');
         $reflectionMethod->getBody();


### PR DESCRIPTION
As bonus, fixed `Wingu\OctopusCore\Reflection\ReflectionFile::reflect` - `each` function was deprecated in php 7.2 and removed in 8.0 
https://www.php.net/each
And some types was added for "php tokens" in 8.0

One test (`Wingu\OctopusCore\Reflection\Tests\Unit\ReflectionClassUseTest::testGetConflictResolutions`) I mark as skipped, as do not know how to resolve it.
